### PR TITLE
Fix Docker build: allow .env.example in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,5 +61,6 @@ Thumbs.db
 *~
 .env*
 .flaskenv*
+!.env.example
 !.env.project
 !.env.vault


### PR DESCRIPTION
## Summary
- Fix Docker build error by allowing .env.example in build context
- Add `\!.env.example` to .dockerignore to override `.env*` exclusion

## Problem
The Docker build was failing with:
```
ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref: "/.env.example": not found
```

## Solution
The `.dockerignore` file was excluding all `.env*` files, but the Dockerfile needs `.env.example` for reference. Added explicit inclusion rule to override the exclusion.

## Test Plan
- [x] Docker build should now succeed
- [x] GitHub Actions build workflow should pass

🤖 Generated with [Claude Code](https://claude.ai/code)