### PR TITLE
Replace TOON with GCF: 28.5% fewer tokens on Cisco API data

### DIFF
--- a/benchmarks/benchmark.mjs
+++ b/benchmarks/benchmark.mjs
@@ -1,0 +1,208 @@
+/**
+ * GCF vs TOON vs JSON benchmark + TOON corruption proof on Cisco support data.
+ * GCF = Graph Compact Format (https://gcformat.com)
+ *
+ * Uses realistic data shapes from Cisco Support APIs:
+ * - Bug API responses (bug_id, headline, status, severity)
+ * - Case API responses (case_id, title, status, severity)
+ * - EoX API responses (EOLProductID, dates, error records)
+ * - Error responses (flat objects with error messages)
+ *
+ * Usage: node benchmarks/benchmark.mjs
+ */
+
+import { encode as toonEncode, decode as toonDecode } from '@toon-format/toon';
+import { encodeGeneric, decodeGeneric } from '@blackwell-systems/gcf';
+
+function tokenEstimate(text) {
+  return Math.max(1, Math.floor(text.length / 4));
+}
+
+// --- Realistic Cisco Support API data generators ---
+
+function generateBugResponse(n) {
+  return {
+    bugs: Array.from({ length: n }, (_, i) => ({
+      bug_id: `CSCvx${String(10000 + i).padStart(5, '0')}`,
+      headline: `[${['IOS-XE', 'NX-OS', 'ASA', 'ISE', 'DNAC'][i % 5]}]: ${['Memory leak in process', 'Interface flap on reload', 'SNMP polling timeout', 'Authentication bypass in RADIUS', 'BGP session drops under load'][i % 5]}`,
+      status: ['O', 'F', 'T', 'R', 'V'][i % 5],
+      severity: `${1 + (i % 6)}`,
+      last_modified_date: `2026-0${1 + (i % 9)}-${String(10 + (i % 20)).padStart(2, '0')}T10:00:00Z`,
+      product: `Cisco ${['Catalyst 9300', 'Nexus 9000', 'ASA 5500', 'ISE 3.x', 'DNA Center'][i % 5]}`,
+      known_affected_releases: [`${15 + (i % 3)}.${i % 10}.${i % 5}`, `${16 + (i % 2)}.${i % 8}.${i % 3}`],
+      known_fixed_releases: [`${17 + (i % 2)}.${i % 6}.${i % 4}`],
+      description: `Bug found in ${['show running-config', 'interface GigabitEthernet0/1', 'router bgp 65000', 'aaa authentication login'][i % 4]}. Error: ERR[${400 + (i % 10)}]: ${['Not Found', 'Forbidden', 'Timeout', 'Service Unavailable', 'Bad Gateway'][i % 5]}.`,
+    })),
+    total_results: n,
+  };
+}
+
+function generateCaseResponse(n) {
+  return {
+    cases: Array.from({ length: n }, (_, i) => ({
+      case_id: `SR ${600000000 + i}`,
+      title: `[P${1 + (i % 4)}]: ${['Router crash on reload', 'Switch port security violation', 'VPN tunnel intermittent drops', 'License compliance issue', 'Firmware upgrade failure'][i % 5]}`,
+      status: ['Open', 'Customer Pending', 'Engineer Assigned', 'Closed', 'Resolved'][i % 5],
+      severity: `${1 + (i % 4)}`,
+      created_date: `2026-0${1 + (i % 9)}-${String(1 + (i % 28)).padStart(2, '0')}`,
+      last_modified_date: `2026-06-${String(1 + (i % 18)).padStart(2, '0')}`,
+      contract_id: `CON-SNT-${['C93002', 'N9K96', 'ASA55', 'ISE30', 'DNAC2'][i % 5]}${i}`,
+      serial_number: `FCW${2100 + i}${String.fromCharCode(65 + (i % 26))}${String.fromCharCode(65 + ((i + 7) % 26))}${String.fromCharCode(65 + ((i + 13) % 26))}`,
+    })),
+    total_results: n,
+  };
+}
+
+function generateEoxResponse(n) {
+  return {
+    EOXRecord: Array.from({ length: n }, (_, i) => ({
+      EOLProductID: `WS-C${3750 + (i % 50)}X-${24 + (i % 4) * 12}${['T', 'P', 'S'][i % 3]}-${['S', 'L', 'E'][i % 3]}`,
+      ProductIDDescription: `Cisco Catalyst ${3750 + (i % 50)}X ${24 + (i % 4) * 12}-Port ${['10/100/1000', 'PoE+', 'SFP+'][i % 3]}`,
+      ProductBulletinNumber: `EOL${14000 + i}`,
+      LinkToProductBulletinURL: `https://www.cisco.com/c/en/us/products/collateral/switches/eol${14000 + i}.html`,
+      EOXExternalAnnouncementDate: { dateFormat: 'YYYY-MM-DD', value: `202${3 + (i % 3)}-0${1 + (i % 9)}-01` },
+      EndOfSaleDate: { dateFormat: 'YYYY-MM-DD', value: `202${4 + (i % 3)}-0${1 + (i % 9)}-01` },
+      EndOfSWMaintenanceReleases: { dateFormat: 'YYYY-MM-DD', value: `202${5 + (i % 3)}-0${1 + (i % 9)}-01` },
+      LastDateOfSupport: { dateFormat: 'YYYY-MM-DD', value: `202${8 + (i % 3)}-0${1 + (i % 9)}-01` },
+      EOXError: i % 7 === 0 ? {
+        ErrorID: `ERR[${400 + (i % 5)}]`,
+        ErrorDescription: `[ProductID]: ${['Not found in database', 'Invalid format', 'Deprecated endpoint'][i % 3]}`,
+      } : null,
+      EOXInputType: 'ShowEoXByPids',
+      EOXInputValue: `WS-C${3750 + (i % 50)}X`,
+    })),
+    PaginationResponseRecord: {
+      PageIndex: 1,
+      LastIndex: Math.ceil(n / 20),
+      TotalRecords: n,
+      PageRecords: Math.min(n, 20),
+    },
+  };
+}
+
+function generateErrorResponses(n) {
+  return Array.from({ length: n }, (_, i) => ({
+    error: `ERR[${400 + (i % 5)}]: ${['Not Found', 'Unauthorized', 'Forbidden', 'Rate Limited', 'Internal Server Error'][i % 5]}`,
+    message: `API request failed for endpoint /api/v2/${['bugs', 'cases', 'eox', 'product'][i % 4]}`,
+    timestamp: `2026-06-18T${String(10 + (i % 12)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`,
+    request_id: `req-${i}-${Date.now()}`,
+  }));
+}
+
+// =====================================================================
+// PART 1: TOKEN BENCHMARK
+// =====================================================================
+
+console.log('='.repeat(80));
+console.log('PART 1: Token Benchmark — GCF vs TOON vs JSON on Cisco Support Data');
+console.log('='.repeat(80));
+console.log();
+
+const datasets = [
+  { name: 'Bug API (50)', data: generateBugResponse(50) },
+  { name: 'Case API (50)', data: generateCaseResponse(50) },
+  { name: 'EoX API (50)', data: generateEoxResponse(50) },
+  { name: 'Bug API (200)', data: generateBugResponse(200) },
+  { name: 'Case API (200)', data: generateCaseResponse(200) },
+  { name: 'EoX API (200)', data: generateEoxResponse(200) },
+];
+
+console.log(
+  `${'Dataset'.padEnd(20)}  ${'JSON'.padStart(8)}  ${'TOON'.padStart(8)}  ${'GCF'.padStart(8)}  ${'TOON%'.padStart(7)}  ${'GCF%'.padStart(7)}  ${'GCF vs TOON'.padStart(12)}`
+);
+console.log('-'.repeat(80));
+
+let totalJson = 0, totalToon = 0, totalGcf = 0;
+
+for (const { name, data } of datasets) {
+  const jsonStr = JSON.stringify(data);
+  const toonStr = toonEncode(data);
+  const gcfStr = encodeGeneric(data);
+
+  const jsonTok = tokenEstimate(jsonStr);
+  const toonTok = tokenEstimate(toonStr);
+  const gcfTok = tokenEstimate(gcfStr);
+
+  totalJson += jsonTok;
+  totalToon += toonTok;
+  totalGcf += gcfTok;
+
+  const toonPct = ((1 - toonTok / jsonTok) * 100).toFixed(1);
+  const gcfPct = ((1 - gcfTok / jsonTok) * 100).toFixed(1);
+  const gcfVsToon = ((1 - gcfTok / toonTok) * 100).toFixed(1);
+
+  console.log(
+    `${name.padEnd(20)}  ${String(jsonTok).padStart(8)}  ${String(toonTok).padStart(8)}  ${String(gcfTok).padStart(8)}  ${(toonPct + '%').padStart(7)}  ${(gcfPct + '%').padStart(7)}  ${((gcfVsToon > 0 ? '+' : '') + gcfVsToon + '%').padStart(12)}`
+  );
+}
+
+console.log('-'.repeat(80));
+const toonTotalPct = ((1 - totalToon / totalJson) * 100).toFixed(1);
+const gcfTotalPct = ((1 - totalGcf / totalJson) * 100).toFixed(1);
+const gcfVsToonTotal = ((1 - totalGcf / totalToon) * 100).toFixed(1);
+console.log(
+  `${'TOTAL'.padEnd(20)}  ${String(totalJson).padStart(8)}  ${String(totalToon).padStart(8)}  ${String(totalGcf).padStart(8)}  ${(toonTotalPct + '%').padStart(7)}  ${(gcfTotalPct + '%').padStart(7)}  ${((gcfVsToonTotal > 0 ? '+' : '') + gcfVsToonTotal + '%').padStart(12)}`
+);
+
+// =====================================================================
+// PART 2: TOON CORRUPTION PROOF
+// =====================================================================
+
+console.log();
+console.log('='.repeat(80));
+console.log('PART 2: TOON Corruption Proof — Round-Trip on Individual Records');
+console.log('='.repeat(80));
+console.log();
+
+// Test individual flat objects (error responses, single bug records, EoX errors)
+const testRecords = [
+  ...generateErrorResponses(10),
+  ...generateBugResponse(10).bugs,
+  ...generateEoxResponse(10).EOXRecord.filter(r => r.EOXError),
+];
+
+let toonCorruptions = 0;
+let toonErrors = 0;
+let gcfCorruptions = 0;
+let gcfErrors = 0;
+
+for (const record of testRecords) {
+  try {
+    const encoded = toonEncode(record);
+    const decoded = toonDecode(encoded);
+    if (JSON.stringify(decoded) !== JSON.stringify(record)) {
+      toonCorruptions++;
+      if (toonCorruptions <= 3) {
+        console.log(`TOON SILENT CORRUPTION:`);
+        console.log(`  Original: ${JSON.stringify(record).slice(0, 120)}...`);
+        console.log(`  Decoded:  ${JSON.stringify(decoded).slice(0, 120)}...`);
+        console.log();
+      }
+    }
+  } catch (e) {
+    toonErrors++;
+    if (toonErrors <= 5) {
+      console.log(`TOON DECODE ERROR: ${e.message}`);
+      console.log(`  Record: ${JSON.stringify(record).slice(0, 120)}...`);
+      console.log();
+    }
+  }
+
+  try {
+    const encoded = encodeGeneric(record);
+    const decoded = decodeGeneric(encoded);
+    if (JSON.stringify(decoded) !== JSON.stringify(record)) {
+      gcfCorruptions++;
+    }
+  } catch (e) {
+    gcfErrors++;
+  }
+}
+
+console.log('='.repeat(80));
+console.log('SUMMARY');
+console.log('='.repeat(80));
+console.log();
+console.log(`Records tested: ${testRecords.length}`);
+console.log(`TOON corruptions: ${toonCorruptions} | TOON errors: ${toonErrors} | Total failures: ${toonCorruptions + toonErrors}/${testRecords.length}`);
+console.log(`GCF corruptions:  ${gcfCorruptions} | GCF errors:  ${gcfErrors} | Total failures: ${gcfCorruptions + gcfErrors}/${testRecords.length}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
+        "@blackwell-systems/gcf": "^2.1.2",
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@toon-format/toon": "^1.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -586,6 +586,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@blackwell-systems/gcf": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@blackwell-systems/gcf/-/gcf-2.1.2.tgz",
+      "integrity": "sha512-IKSqfNwXX2O0Xn+c1mTKZW261n5Cruj66y/M2CgfxvPqNRNJhwP0CGokkzA/mLUSgnus4FO3a00m4WHSKJD8pA==",
+      "license": "MIT",
+      "bin": {
+        "gcf": "dist/cli.js"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -1734,12 +1743,6 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
-    },
-    "node_modules/@toon-format/toon": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-1.0.0.tgz",
-      "integrity": "sha512-2gIk8LaqrzpurNDaDWZ72kucAGcBbxJxUnp+4ZP+Pny/QVNdMVf97yzSDTI3ed2q8ypjj8T271P6iE3bRmQBNw==",
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "homepage": "https://github.com/sieteunoseis/mcp-cisco-support#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "@toon-format/toon": "^1.0.0",
+    "@blackwell-systems/gcf": "^2.1.2",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/src/utils/toon-formatter.ts
+++ b/src/utils/toon-formatter.ts
@@ -4,10 +4,12 @@ import {
   CaseApiResponse,
   EoxApiResponse,
 } from "./formatting.js";
+import { encodeGeneric } from "@blackwell-systems/gcf";
 
 /**
- * Convert API responses to TOON format
- * TOON (Text Object-Oriented Notation) provides a more readable and structured output
+ * Convert API responses to GCF (Graph Compact Format)
+ * GCF provides 28.5% fewer tokens than JSON on Cisco API data,
+ * with 90.7% LLM comprehension accuracy (vs 53.6% JSON).
  */
 
 export async function convertToToonFormat(
@@ -15,14 +17,9 @@ export async function convertToToonFormat(
   apiType: string,
 ): Promise<string> {
   try {
-    const { encode } = await import("@toon-format/toon");
-    const toonOutput = encode(data, {
-      indent: 2,
-    });
-
-    return toonOutput;
+    return encodeGeneric(data);
   } catch (error) {
-    console.error("TOON formatting error:", error);
+    console.error("GCF formatting error:", error);
     return JSON.stringify(data, null, 2);
   }
 }
@@ -51,18 +48,18 @@ export async function eoxResponseToToon(data: EoxApiResponse): Promise<string> {
 }
 
 /**
- * Determine if TOON format should be used based on environment variable
- * Defaults to true (TOON enabled) unless explicitly disabled
+ * Determine if compact format should be used based on environment variable
+ * Defaults to true (GCF enabled) unless explicitly disabled
  */
 export function shouldUseToonFormat(): boolean {
-  const toonDisabled =
+  const disabled =
     process.env.DISABLE_TOON_FORMAT?.toLowerCase() === "true";
-  return !toonDisabled;
+  return !disabled;
 }
 
 /**
  * Get format description for logging/debugging
  */
 export function getFormatDescription(): string {
-  return shouldUseToonFormat() ? "TOON" : "JSON";
+  return shouldUseToonFormat() ? "GCF" : "JSON";
 }


### PR DESCRIPTION
## Summary

- Replace `@toon-format/toon` with `@blackwell-systems/gcf` in `toon-formatter.ts`
- One file change, one dep swap. All callers unchanged.
- Existing `DISABLE_TOON_FORMAT` env var still works

## Why

### Benchmarked on Cisco Support API data

TOON provides minimal savings on Cisco API responses and actually increases token count on 2 of 3 API types compared to compact JSON:

| Dataset | JSON | TOON | GCF | TOON % | GCF % | GCF vs TOON |
|---------|------|------|-----|--------|-------|-------------|
| Bug API (50) | 4,190 | 4,427 | 3,109 | -5.7% | 25.8% | +29.8% |
| Case API (50) | 2,882 | 1,454 | 1,435 | 49.5% | 50.2% | +1.3% |
| EoX API (50) | 7,664 | 8,193 | 6,055 | -6.9% | 21.0% | +26.1% |
| Bug API (200) | 16,735 | 17,684 | 12,342 | -5.7% | 26.3% | +30.2% |
| Case API (200) | 11,540 | 5,762 | 5,668 | 50.1% | 50.9% | +1.6% |
| EoX API (200) | 30,525 | 32,633 | 23,935 | -6.9% | 21.6% | +26.7% |
| **Total** | **73,536** | **70,153** | **52,544** | **4.6%** | **28.5%** | **+25.1%** |

TOON increases token count on Bug API (-5.7%) and EoX API (-6.9%) compared to compact JSON. GCF saves 28.5% overall and uses 25.1% fewer tokens than TOON.

Reproduce: `node benchmarks/benchmark.mjs`

### LLM comprehension

GCF scores 100% on general structured data and 90.7% on adversarial payloads across GPT-4o, GPT-5.5, Claude, and Gemini. JSON drops to 53.6% on the same data. TOON scores 68.5%. (1,700+ evaluations.)

Full eval methodology: [GCF benchmarks](https://gcformat.com/guide/benchmarks)

### Data integrity

TOON's encoder does not quote string values containing bracket-colon patterns (e.g. `ERR[404]: Not Found`). This produces structurally ambiguous output that can be misinterpreted by downstream consumers. Cisco error responses are particularly affected since they commonly contain error codes in this format. On round-trip testing of individual Cisco API records, TOON fails on 20 of 22 records. GCF: zero failures.

GCF verified lossless across 33 billion+ round-trips in 5 formats and 6 languages.

Full verification data: [Lossless verification](https://gcformat.com/guide/lossless-verification)

### Zero runtime dependencies

`@blackwell-systems/gcf` has zero runtime dependencies, same as `@toon-format/toon`.

### Adopted by other MCP servers

[NetClaw](https://github.com/wavequery/NetClaw) (556 stars), an MCP server for network diagnostics, recently adopted GCF for the same reasons.

## Changes

| File | Change |
|------|--------|
| `src/utils/toon-formatter.ts` | `@toon-format/toon` → `@blackwell-systems/gcf` |
| `package.json` | Dependency swap |
| `benchmarks/benchmark.mjs` | New: benchmark on Cisco API data |

## Links

- GCF spec and docs: https://gcformat.com
- GCF TypeScript SDK: https://www.npmjs.com/package/@blackwell-systems/gcf
- SDKs in 6 languages: https://gcformat.com/guide/getting-started
- Eval results: https://gcformat.com/guide/eval-results
- Lossless verification: https://gcformat.com/guide/lossless-verification
- TOON comparison: https://gcformat.com/guide/vs-toon
- Whitepaper: https://gcformat.com/whitepaper